### PR TITLE
Implement persistent content saving and viewing

### DIFF
--- a/src/app/api/content/save/route.ts
+++ b/src/app/api/content/save/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase-server'
+import { ContentType, ContentTone, ContentStatus } from '@/types'
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = createClient()
+    
+    // DOGFOODING MODE: Skip auth check
+    const user = { id: '00000000-0000-0000-0000-000000000001' }
+
+    const { 
+      title,
+      content,
+      content_type,
+      tone,
+      topic,
+      status = 'draft',
+      target_audience,
+      additional_instructions,
+      tags = [],
+      word_count,
+      estimated_read_time
+    } = await request.json()
+
+    if (!content || !content_type || !tone || !topic) {
+      return NextResponse.json(
+        { error: 'Content, content_type, tone, and topic are required' },
+        { status: 400 }
+      )
+    }
+
+    // Generate title if not provided
+    const contentTitle = title || `${topic} - ${new Date().toLocaleDateString('ko-KR')}`
+
+    // Save content to database
+    const { data: contentData, error: contentError } = await supabase
+      .from('contents')
+      .insert({
+        user_id: user.id,
+        title: contentTitle,
+        content,
+        content_type,
+        tone,
+        topic,
+        status,
+        target_audience,
+        additional_instructions,
+        tags,
+        word_count: word_count || content.split(/\s+/).length,
+        estimated_read_time: estimated_read_time || Math.ceil(content.split(/\s+/).length / 200),
+        auto_generated: true
+      })
+      .select()
+      .single()
+
+    if (contentError) {
+      console.error('Error saving content:', contentError)
+      return NextResponse.json(
+        { error: 'Failed to save content' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json(contentData)
+  } catch (error) {
+    console.error('Error saving content:', error)
+    return NextResponse.json(
+      { error: 'Failed to save content' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement permanent content saving and display saved content on the content library page.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the "임시저장" (temporary save) button did not actually persist content. This change enables real content saving, making generated content viewable and manageable from the content library, utilizing `localStorage` for persistence in the current demo environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-41d34290-2f6d-4f49-a02a-e245d47562b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41d34290-2f6d-4f49-a02a-e245d47562b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

