### PR TITLE
Remove 500 character limit for video scripts

### DIFF
--- a/src/app/api/content/generate-scheduled/route.ts
+++ b/src/app/api/content/generate-scheduled/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase-server'
 import { anthropic } from '@/lib/claude'
 import { scheduleContentGeneration, calculateNextRun } from '@/lib/qstash'
-import { CREATIVITY_LEVELS } from '@/utils/constants'
+import { CREATIVITY_LEVELS, getCharacterLimitPromptText } from '@/utils/constants'
 
 // 완전히 새로운 v2 API - 안전한 구조로 재작성
 async function handler(request: NextRequest) {
@@ -119,7 +119,7 @@ async function handler(request: NextRequest) {
         top_p: creativitySettings.top_p || 1.0,
         messages: [{ role: 'user', content: `Create high-quality Korean content based on these parameters:\n\n${enhancedPrompt}\n\nIMPORTANT: 
 - Write in Korean (한국어)
-- KEEP IT CONCISE: Maximum 500 characters including spaces (공백 포함 500자 이내)
+- KEEP IT CONCISE: ${getCharacterLimitPromptText(schedule.content_type || 'x_post')}
 - Write naturally like a human, avoid AI-like formatting
 - NO markdown syntax (no #, ##, **, -, •, etc.)
 - Use plain text with natural paragraph breaks

--- a/src/app/api/content/generate/route.ts
+++ b/src/app/api/content/generate/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase-server'
 import { anthropic } from '@/lib/claude'
 import { ContentType, ContentTone } from '@/types'
-import { CONTENT_TYPE_SPECS, CREATIVITY_LEVELS } from '@/utils/constants'
+import { CONTENT_TYPE_SPECS, CREATIVITY_LEVELS, getCharacterLimitPromptText } from '@/utils/constants'
 import { getDatabasePromptTemplate, logPromptUsage } from '@/utils/db-prompt-templates'
 import { evaluateAndSaveContent } from '@/lib/evaluation'
 
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
           role: 'user',
           content: `Create high-quality Korean content based on these parameters:\n\n${enhancedPrompt}\n\nIMPORTANT: 
 - Write in Korean (한국어)
-- KEEP IT CONCISE: Maximum 500 characters including spaces (공백 포함 500자 이내)
+- KEEP IT CONCISE: ${getCharacterLimitPromptText(requestData.type || 'x_post')}
 - Write naturally like a human, avoid AI-like formatting
 - NO markdown syntax (no #, ##, **, -, •, etc.)
 - Use plain text with natural paragraph breaks

--- a/src/app/api/schedule/run/route.ts
+++ b/src/app/api/schedule/run/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase-server'
 import { anthropic } from '@/lib/claude'
-import { CREATIVITY_LEVELS } from '@/utils/constants'
+import { CREATIVITY_LEVELS, getCharacterLimitPromptText } from '@/utils/constants'
 
 // 스케줄 즉시 실행 (테스트용)
 export async function POST(request: NextRequest) {
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
           role: 'user',
           content: `Create high-quality Korean content based on these parameters:\n\n${enhancedPrompt}\n\nIMPORTANT: 
 - Write in Korean (한국어)
-- KEEP IT CONCISE: Maximum 500 characters including spaces (공백 포함 500자 이내)
+- KEEP IT CONCISE: ${getCharacterLimitPromptText(schedule.content_type || 'x_post')}
 - Write naturally like a human, avoid AI-like formatting
 - NO markdown syntax (no #, ##, **, -, •, etc.)
 - Use plain text with natural paragraph breaks

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -290,3 +290,13 @@ export const CREATIVITY_LEVELS = {
     description: '예측 불가능하고 독특한 콘텐츠'
   }
 } as const
+
+export const getCharacterLimitForContentType = (contentType: string): number => {
+  const spec = CONTENT_TYPE_SPECS[contentType as keyof typeof CONTENT_TYPE_SPECS]
+  return spec?.maxLength || 500 // fallback to 500 for unknown types
+}
+
+export const getCharacterLimitPromptText = (contentType: string): string => {
+  const limit = getCharacterLimitForContentType(contentType)
+  return `Maximum ${limit} characters including spaces (공백 포함 ${limit}자 이내)`
+}


### PR DESCRIPTION
Dynamically adjust AI prompt character limits based on content type to allow for more appropriate lengths for YouTube scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ece153f-2dcc-4a9f-9aa5-9357e01c7ab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ece153f-2dcc-4a9f-9aa5-9357e01c7ab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

