### PR TITLE
Remove core competitiveness text, keep icon

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -127,7 +127,7 @@ export default function HomePage() {
               maxW="5xl"
               mx="auto"
             >
-              {/* 핵심 경쟁력: 클리셰 기반 생성 */}
+              {/* 클리셰 기반 생성 */}
               <Card 
                 shadow="xl"
                 borderRadius="xl"

--- a/src/components/content/ContentForm.tsx
+++ b/src/components/content/ContentForm.tsx
@@ -138,7 +138,7 @@ export default function ContentForm({ onSubmit }: ContentFormProps) {
               />
             </FormControl>
 
-            {/* 핵심 경쟁력: 클리셰 선택 영역 */}
+            {/* 클리셰 선택 영역 */}
             <Box
               position="relative"
               p={6}
@@ -204,7 +204,7 @@ export default function ContentForm({ onSubmit }: ContentFormProps) {
                       }
                     }}
                   >
-                    🏆 핵심 경쟁력
+                    🏆
                   </Badge>
                 </HStack>
                 


### PR DESCRIPTION
Remove "핵심경쟁력" text from the UI and related comments to keep only the icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe334482-9dba-45db-81b7-1b59b5f1e79b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe334482-9dba-45db-81b7-1b59b5f1e79b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

