### PR TITLE
Enhance ai variable generation with clichés

### DIFF
--- a/src/app/api/content/ai-suggestions/route.ts
+++ b/src/app/api/content/ai-suggestions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { anthropic } from '@/lib/claude'
 import { ContentType } from '@/types'
+import { getFieldsForContentType, CONTENT_TYPE_SPECIFIC_FIELDS } from '@/utils/content-type-fields'
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,6 +16,21 @@ export async function POST(request: NextRequest) {
 
     console.log('🤖 Generating AI variable suggestions for:', { topic, contentType })
 
+    // 클리셰별 전용 필드 정보 가져오기
+    const clicheFields = getFieldsForContentType(contentType)
+    
+    // 클리셰별 필드 정보를 AI 프롬프트에 포함하기 위한 텍스트 생성
+    let clicheFieldsContext = ''
+    if (clicheFields.length > 0) {
+      clicheFieldsContext = `
+
+이 콘텐츠 클리셰에는 다음과 같은 전용 변수들이 있습니다. 이 변수들을 참고하여 더 구체적이고 맞춤형 제안을 해주세요:
+
+${clicheFields.map(field => `• ${field.label} (${field.key}): ${field.placeholder}`).join('\n')}
+
+위 전용 변수들의 특성을 고려하여, 주제 "${topic}"에 맞는 구체적인 값들을 제안해주세요.`
+    }
+
     const message = await anthropic.messages.create({
       model: 'claude-sonnet-4-20250514',
       max_tokens: 1500,
@@ -22,7 +38,7 @@ export async function POST(request: NextRequest) {
       messages: [
         {
           role: 'user',
-          content: `주제 "${topic}"와 콘텐츠 타입 "${contentType}"에 최적화된 추가 요청사항 변수들을 생성해주세요.
+          content: `주제 "${topic}"와 콘텐츠 타입 "${contentType}"에 최적화된 추가 요청사항 변수들을 생성해주세요.${clicheFieldsContext}
 
 다음 형식으로 실용적이고 구체적인 변수들을 제안해주세요:
 

--- a/src/components/content/ContentForm.tsx
+++ b/src/components/content/ContentForm.tsx
@@ -153,10 +153,22 @@ export default function ContentForm({ onSubmit }: ContentFormProps) {
 
       const data = await response.json()
       
-      // 기존 내용과 AI 제안을 결합
+      // 클리셰별 기본 변수들과 AI 제안을 효과적으로 결합
+      const fields = getFieldsForContentType(formData.contentType)
+      let combinedSuggestions = ''
+      
+      if (fields.length > 0) {
+        combinedSuggestions += `📋 ${CONTENT_TYPE_LABELS[formData.contentType]} 전용 변수들:\n`
+        combinedSuggestions += fields.map(field => `${field.key} (${field.label}): ${field.placeholder}`).join('\n')
+        combinedSuggestions += '\n\n'
+      }
+      
+      combinedSuggestions += `🤖 AI 맞춤 제안 (주제: "${formData.topic}"):\n${data.suggestions}`
+      
+      // 기존 내용과 결합된 제안을 추가
       const newAdditionalNotes = formData.additionalNotes 
-        ? `${formData.additionalNotes}\n\n🤖 AI 제안:\n${data.suggestions}`
-        : `🤖 AI 제안:\n${data.suggestions}`
+        ? `${formData.additionalNotes}\n\n${combinedSuggestions}`
+        : combinedSuggestions
       
       setFormData(prev => ({ 
         ...prev, 
@@ -165,9 +177,9 @@ export default function ContentForm({ onSubmit }: ContentFormProps) {
 
       toast({
         title: '✨ AI 제안 완료',
-        description: '주제에 맞는 변수 설정을 추가했습니다',
+        description: '클리셰별 전용 변수와 주제 맞춤 제안을 모두 추가했습니다',
         status: 'success',
-        duration: 3000,
+        duration: 4000,
       })
     } catch (error) {
       console.error('AI suggestions error:', error)
@@ -410,7 +422,7 @@ export default function ContentForm({ onSubmit }: ContentFormProps) {
                 minH="150px"
               />
               <FormHelperText color="gray.500">
-                💡 콘텐츠 클리셰별 전용 변수들이 자동으로 표시됩니다. 우측 상단의 🤖✨ 버튼을 클릭하면 AI가 주제에 맞는 최적화된 변수 설정을 제안해드립니다.
+                💡 콘텐츠 클리셰별 전용 변수들이 자동으로 표시됩니다. 우측 상단의 🤖✨ 버튼을 클릭하면 AI가 클리셰의 기본 변수들과 주제를 모두 고려하여 최적화된 변수 설정을 제안해드립니다.
               </FormHelperText>
             </FormControl>
 


### PR DESCRIPTION
Enhance AI variable suggestions to incorporate cliche-specific default variables for more relevant outputs.

Previously, the AI only considered the topic. This change integrates the predefined variables for each content cliche, allowing the AI to generate suggestions that are both topic-specific and aligned with the chosen cliche's structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-c94ee689-dc45-446b-8da8-a059bf11898e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c94ee689-dc45-446b-8da8-a059bf11898e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

